### PR TITLE
Prepare for release v0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	k8s.io/klog/v2 v2.130.1
 	kmodules.xyz/client-go v0.32.7
 	kmodules.xyz/custom-resources v0.32.0
-	kubedb.dev/apimachinery v0.57.0-rc.0
+	kubedb.dev/apimachinery v0.57.0
 	sigs.k8s.io/controller-runtime v0.20.4
 	xorm.io/xorm v1.3.9
 )

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ kmodules.xyz/monitoring-agent-api v0.32.1 h1:F0cm5NJWfgiANw3eiKkXXSXoClMBpAolMXE
 kmodules.xyz/monitoring-agent-api v0.32.1/go.mod h1:zgRKiJcuK7FOHy0Y1TsONRbJfgnPCs8t4Zh/6Afr+yU=
 kmodules.xyz/offshoot-api v0.32.0 h1:gogc5scSZe2JoXtZof72UGRl3Tit0kFaFRMkLLT1D8o=
 kmodules.xyz/offshoot-api v0.32.0/go.mod h1:tled7OxYZ3SkUJcrVFVVYyd+zXjsRSEm1R6Q3k4gcx0=
-kubedb.dev/apimachinery v0.57.0-rc.0 h1:dMG7/HFzIR4XqQmvUZ2llcKSezEuNONFvL6h2PXkeVw=
-kubedb.dev/apimachinery v0.57.0-rc.0/go.mod h1:JtzH/EKGsg1h5eOuaihY1g+RhpyPBHn+KUsn9or4Z0M=
+kubedb.dev/apimachinery v0.57.0 h1:Ia6LlkDxbK/NbUMhLGM92QqHQAHr4g0wWxdVtjXMvEU=
+kubedb.dev/apimachinery v0.57.0/go.mod h1:STmyKaUgTJ3mspOrb9xjwhYyj68c6v6R1kjpPyNu9KY=
 kubeops.dev/petset v0.0.11 h1:tlcGhGN+9wMYHXvGkSNz48ziozJFEknWaDj5YUws3kQ=
 kubeops.dev/petset v0.0.11/go.mod h1:veOaOzhp1GVKeI1QAV0z6p0WDtCShwkFXiqgxwYNoBo=
 kubeops.dev/sidekick v0.0.11 h1:OydXdIH6cYSiWxKIWvrywk95WhhHSERkc7RNPOmTekc=

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/constants.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/constants.go
@@ -41,6 +41,7 @@ const (
 	DistributedRBACNameSuffix               = "rbac"
 	DistributedServiceExportNameSuffix      = "serviceexports"
 	DistributedTLSSecretNameSuffix          = "tls-secrets"
+	DistributedGRPCSecretNameSuffix         = "grpc-secrets"
 	DistributedAuthSecretNameSuffix         = "auth"
 	KubeSliceNSMIPKey                       = "kubeslice.io/nsmIP"
 	KubeSlicePodIPVolumeName                = "podip"
@@ -475,6 +476,8 @@ const (
 	MSSQLVolumeMountPathConfig                 = "/var/opt/mssql/mssql.conf"
 	MSSQLVolumeNameInitScript                  = "init-scripts"
 	MSSQLVolumeMountPathInitScript             = "/scripts"
+	MSSQLVolumeNameInitDatabase                = "init-database"
+	MSSQLVolumeMountPathInitDatabase           = "/init-database"
 	MSSQLVolumeNameEndpointCert                = "endpoint-cert"
 	MSSQLVolumeMountPathEndpointCert           = "/var/opt/mssql/endpoint-cert"
 	MSSQLVolumeNameCerts                       = "certs"
@@ -552,6 +555,9 @@ const (
 	IPS_LOCK                  = "IPC_LOCK"
 	SYS_RESOURCE              = "SYS_RESOURCE"
 	DropCapabilityALL         = "ALL"
+
+	PostgresGRPCIssuerName           = "grpc-issuer"
+	PostgresGRPCSelfSignedIssuerName = "grpc-selfsigned"
 
 	// =========================== ProxySQL Constants ============================
 	LabelProxySQLName                  = ProxySQLKey + "/name"

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1/postgres_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1/postgres_helpers.go
@@ -163,6 +163,18 @@ func (p Postgres) OffshootDistributedConfigSecretName() string {
 	return meta_util.NameWithSuffix(p.Name, kubedb.DistributedCustomConfigSecretNameSuffix)
 }
 
+func (p Postgres) GetGRPCSelfSignedIssuerName() string {
+	return meta_util.NameWithSuffix(p.OffshootName(), kubedb.PostgresGRPCSelfSignedIssuerName)
+}
+
+func (p Postgres) GetGRPCIssuerName() string {
+	return meta_util.NameWithSuffix(p.OffshootName(), kubedb.PostgresGRPCIssuerName)
+}
+
+func (p Postgres) OffshootDistributedGRPCSecretName() string {
+	return meta_util.NameWithSuffix(p.OffshootName(), kubedb.DistributedGRPCSecretNameSuffix)
+}
+
 type postgresApp struct {
 	*Postgres
 }

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1/postgres_types.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1/postgres_types.go
@@ -273,6 +273,9 @@ const (
 	PostgresServerCert          PostgresCertificateAlias = "server"
 	PostgresClientCert          PostgresCertificateAlias = "client"
 	PostgresArchiverCert        PostgresCertificateAlias = "archiver"
+	PostgresGRPCCaCert          PostgresCertificateAlias = "grpc-ca"
+	PostgresGRPCServerCert      PostgresCertificateAlias = "grpc-server"
+	PostgresGRPCClientCert      PostgresCertificateAlias = "grpc-client"
 	PostgresMetricsExporterCert PostgresCertificateAlias = "metrics-exporter"
 )
 

--- a/vendor/kubedb.dev/apimachinery/crds/archiver.kubedb.com_mariadbarchivers.yaml
+++ b/vendor/kubedb.dev/apimachinery/crds/archiver.kubedb.com_mariadbarchivers.yaml
@@ -634,8 +634,9 @@ spec:
                     enum:
                     - Restic
                     - WalG
-                    - Medusa
                     - VolumeSnapshotter
+                    - Solr
+                    - Medusa
                     type: string
                   jobTemplate:
                     properties:

--- a/vendor/kubedb.dev/apimachinery/crds/archiver.kubedb.com_mongodbarchivers.yaml
+++ b/vendor/kubedb.dev/apimachinery/crds/archiver.kubedb.com_mongodbarchivers.yaml
@@ -634,8 +634,9 @@ spec:
                     enum:
                     - Restic
                     - WalG
-                    - Medusa
                     - VolumeSnapshotter
+                    - Solr
+                    - Medusa
                     type: string
                   jobTemplate:
                     properties:

--- a/vendor/kubedb.dev/apimachinery/crds/archiver.kubedb.com_mssqlserverarchivers.yaml
+++ b/vendor/kubedb.dev/apimachinery/crds/archiver.kubedb.com_mssqlserverarchivers.yaml
@@ -634,8 +634,9 @@ spec:
                     enum:
                     - Restic
                     - WalG
-                    - Medusa
                     - VolumeSnapshotter
+                    - Solr
+                    - Medusa
                     type: string
                   jobTemplate:
                     properties:

--- a/vendor/kubedb.dev/apimachinery/crds/archiver.kubedb.com_mysqlarchivers.yaml
+++ b/vendor/kubedb.dev/apimachinery/crds/archiver.kubedb.com_mysqlarchivers.yaml
@@ -634,8 +634,9 @@ spec:
                     enum:
                     - Restic
                     - WalG
-                    - Medusa
                     - VolumeSnapshotter
+                    - Solr
+                    - Medusa
                     type: string
                   jobTemplate:
                     properties:

--- a/vendor/kubedb.dev/apimachinery/crds/archiver.kubedb.com_postgresarchivers.yaml
+++ b/vendor/kubedb.dev/apimachinery/crds/archiver.kubedb.com_postgresarchivers.yaml
@@ -634,8 +634,9 @@ spec:
                     enum:
                     - Restic
                     - WalG
-                    - Medusa
                     - VolumeSnapshotter
+                    - Solr
+                    - Medusa
                     type: string
                   jobTemplate:
                     properties:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1784,7 +1784,7 @@ kmodules.xyz/offshoot-api/api/v1
 kmodules.xyz/offshoot-api/api/v1/conversion
 kmodules.xyz/offshoot-api/api/v2
 kmodules.xyz/offshoot-api/util
-# kubedb.dev/apimachinery v0.57.0-rc.0
+# kubedb.dev/apimachinery v0.57.0
 ## explicit; go 1.23.6
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/catalog


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2025.7.31
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/116
Signed-off-by: 1gtm <1gtm@appscode.com>