### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/elasticsearch/es_client_v5.go
+++ b/elasticsearch/es_client_v5.go
@@ -289,7 +289,8 @@ func (es *ESClientV5) CountNodes() (int64, error) {
 }
 
 func (es *ESClientV5) AddVotingConfigExclusions(nodes []string) error {
-	url := fmt.Sprintf("/_cluster/voting_config_exclusions/%s?timeout=120s",
+	url := fmt.Sprintf(
+		"/_cluster/voting_config_exclusions/%s?timeout=120s",
 		strings.Join(nodes, ","),
 	)
 

--- a/elasticsearch/es_client_v6.go
+++ b/elasticsearch/es_client_v6.go
@@ -433,7 +433,8 @@ func (es *ESClientV6) CountNodes() (int64, error) {
 }
 
 func (es *ESClientV6) AddVotingConfigExclusions(nodes []string) error {
-	url := fmt.Sprintf("/_cluster/voting_config_exclusions/%s?timeout=120s",
+	url := fmt.Sprintf(
+		"/_cluster/voting_config_exclusions/%s?timeout=120s",
 		strings.Join(nodes, ","),
 	)
 

--- a/ignite/kubedb_client_builder.go
+++ b/ignite/kubedb_client_builder.go
@@ -138,7 +138,8 @@ func (o *KubeDBClientBuilder) GetIgniteDataSource() string {
 	dataSource := fmt.Sprintf(
 		"tcp://%s:%d/PUBLIC?version=1.1.0"+
 			"&timeout=%d",
-		o.Address(), kubedb.IgniteThinPort, o.timeout)
+		o.Address(), kubedb.IgniteThinPort, o.timeout,
+	)
 	return dataSource
 }
 

--- a/neo4j/database.go
+++ b/neo4j/database.go
@@ -491,7 +491,8 @@ func (c *Client) GetSystemDatabaseWriter(ctx context.Context) (string, error) {
 		}
 	}()
 
-	result, err := session.Run(ctx,
+	result, err := session.Run(
+		ctx,
 		`SHOW DATABASES YIELD name, role, address, writer
          WHERE name = 'system' AND writer = true
          RETURN address`,

--- a/neo4j/database.go
+++ b/neo4j/database.go
@@ -435,7 +435,7 @@ func (c *Client) CreateDatabase(ctx context.Context, dbName string, primary, sec
 		query += " " + ql
 	}
 	if len(options) > 0 {
-		var optionParts []string
+		optionParts := make([]string, 0, len(options))
 		for key, value := range options {
 			optionParts = append(optionParts, fmt.Sprintf("%s: '%s'", key, value))
 		}

--- a/rabbitmq/amqp_client.go
+++ b/rabbitmq/amqp_client.go
@@ -68,7 +68,8 @@ func (ch *Channel) PublishMessageOnce(ctx context.Context, queueName string, mes
 		amqp.Publishing{
 			ContentType: "text/plain",
 			Body:        []byte(message),
-		})
+		},
+	)
 	if err != nil {
 		klog.Error(err, "Failed to publish message")
 		return err

--- a/solr/util.go
+++ b/solr/util.go
@@ -464,7 +464,7 @@ func (sc *Client) Down(nodeList []string, x int, mp map[string][]CoreList) error
 	ls1 := nodeList[:n-x]
 	fmt.Println("ls1 ", ls1)
 	fmt.Println("ls2 ", ls2)
-	ar := make([]UpdateList, 0)
+	ar := make([]UpdateList, 0, len(ls2))
 	for _, node := range ls2 {
 		for _, core := range mp[node] {
 			id := -1


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
